### PR TITLE
activity-links.ts refactor

### DIFF
--- a/src/activity_link.ts
+++ b/src/activity_link.ts
@@ -59,26 +59,8 @@ export class ActivityLinks implements ActivityLink {
 
   private validateType(type: string, validTypes: ReversibleMap<string, number>, errorCode: number): void {
     if (!validTypes.has(type)) {
-      throw new CWError(errorCode, `${type} not found.`, { provided: type, options: validTypes });
+      throw new CWError(errorCode, `Activity type "${type}" not found.`, { provided: type, options: validTypes });
     }
-  }
-
-  private setLinkData(sourceType: string, sourceSid: number, destType: string, destSid: number, linkType?: string) {
-    if (typeof linkType !== 'undefined') {
-      return {
-        SourceType: this.activityTypes.get(sourceType),
-        SourceSid: sourceSid,
-        DestType: this.activityTypes.get(destType),
-        DestSid: destSid,
-        LinkType: this.linkTypes.get(linkType)
-      };
-    };
-    return {
-        SourceType: this.activityTypes.get(sourceType),
-        SourceSid: sourceSid,
-        DestType: this.activityTypes.get(destType),
-        DestSid: destSid,
-      };
   }
 
   private transformLinksData(response: any) {
@@ -110,7 +92,14 @@ export class ActivityLinks implements ActivityLink {
       this.validateType(destination_type, this.activityTypes, 2);
       this.validateType(link_type, this.linkTypes, 3);
 
-      let data = this.setLinkData(source_type, source_sid, destination_type, destination_sid, link_type);
+
+      let data = {
+        SourceType: this.activityTypes.get(source_type),
+        SourceSid: source_sid,
+        DestType: this.activityTypes.get(destination_type),
+        DestSid: destination_sid,
+        LinkType: this.linkTypes.get(link_type)
+      }
       let path = 'General/ActivityLink/Add';
 
       this.runRequest(path, data)
@@ -157,7 +146,12 @@ export class ActivityLinks implements ActivityLink {
       this.validateType(source_type, this.activityTypes, 5);
       this.validateType(destination_type, this.activityTypes, 6);
 
-      let data = this.setLinkData(source_type, source_sid, destination_type, destination_sid);
+      let data = {
+        SourceActivityType: this.activityTypes.get(source_type),
+        SourceActivitySid: source_sid,
+        DestinationActivityType: this.activityTypes.get(destination_type),
+        DestinationActivitySid: destination_sid
+      }
       let path = 'General/ActivityLink/CloneByActivitySid';
 
       this.runRequest(path, data)
@@ -181,7 +175,7 @@ export class ActivityLinks implements ActivityLink {
 
       this.runRequest(path, data)
         .then((response: any) => resolve(response))
-        .catch(reject)
+        .catch(reject(false))
     })
   }
 
@@ -201,12 +195,18 @@ export class ActivityLinks implements ActivityLink {
       this.validateType(destination_type, this.activityTypes, 9);
       this.validateType(link_type, this.linkTypes, 10);
 
-      let data = this.setLinkData(source_type, source_sid, destination_type, destination_sid, link_type);
+      let data = {
+        SourceType: this.activityTypes.get(source_type),
+        SourceSid: source_sid,
+        DestType: this.activityTypes.get(destination_type),
+        DestSid: destination_sid,
+        LinkType: this.linkTypes.get(link_type)
+      }
       let path = 'General/ActivityLink/Remove';
 
       this.runRequest(path, data)
-        .then((response: any) => resolve(response.Value))
-        .catach(reject)
+        .then((response: any) => resolve(response))
+        .catch(reject(false))
     })
   }
 }

--- a/src/activity_link.ts
+++ b/src/activity_link.ts
@@ -1,6 +1,5 @@
 import { CWError } from './error'
 import ReversibleMap from 'reversible-map'
-const _ = require('lodash')
 
 /**
  * ActivityLink interface for ActivityLinks
@@ -36,17 +35,63 @@ export class ActivityLinks implements ActivityLink {
   constructor(cw) {
     this.cw = cw
     this.activityTypes = new ReversibleMap<string, number>()
-    this.activityTypes.set("null", 0)
-    this.activityTypes.set("case", 1)
-    this.activityTypes.set("inspection", 2)
-    this.activityTypes.set("request", 3)
-    this.activityTypes.set("workorder", 4)
-    this.activityTypes.set("wipcase", 5)
-
     this.linkTypes = new ReversibleMap<string, number>()
-    this.linkTypes.set("null", 0)
-    this.linkTypes.set("parent", 1)
-    this.linkTypes.set("related", 2)
+
+    this.setActivityTypes();
+    this.setLinkTypes();
+  }
+
+  private setActivityTypes(): void {
+    const activityTypeMappings = ['null', 'case', 'inspection', 'request', 'workorder', 'wipcase'];
+
+    activityTypeMappings.forEach((type, index) => {
+      this.activityTypes.set(type, index);
+    })
+  }
+
+  private setLinkTypes(): void {
+    const linkTypeMappings = ['null', 'parent', 'related'];
+
+    linkTypeMappings.forEach((type, index) => {
+      this.linkTypes.set(type, index);
+    });
+  }
+
+  private validateType(type: string, validTypes: ReversibleMap<string, number>, errorCode: number): void {
+    if (!validTypes.has(type)) {
+      throw new CWError(errorCode, `${type} not found.`, { provided: type, options: validTypes });
+    }
+  }
+
+  private setLinkData(sourceType: string, sourceSid: number, destType: string, destSid: number, linkType?: string) {
+    if (typeof linkType !== 'undefined') {
+      return {
+        SourceType: this.activityTypes.get(sourceType),
+        SourceSid: sourceSid,
+        DestType: this.activityTypes.get(destType),
+        DestSid: destSid,
+        LinkType: this.linkTypes.get(linkType)
+      };
+    };
+    return {
+        SourceType: this.activityTypes.get(sourceType),
+        SourceSid: sourceSid,
+        DestType: this.activityTypes.get(destType),
+        DestSid: destSid,
+      };
+  }
+
+  private transformLinksData(response: any) {
+    return response.Value.map(link => ({
+      DestType: this.activityTypes.get(link.DestType),
+      SourceType: this.activityTypes.get(link.SourceType),
+      LinkType: this.linkTypes.get(link.LinkType),
+      ...link,
+    }));
+  }
+
+  private runRequest(path: string, data: any) {
+    return this.cw.runRequest(path, data);
   }
 
   /**
@@ -61,28 +106,16 @@ export class ActivityLinks implements ActivityLink {
    */
   add(source_type: string, source_sid: number, destination_type: string, destination_sid: number, link_type: string = 'related') {
     return new Promise((resolve, reject) => {
-      if(!this.activityTypes.has(source_type)) {
-        reject(new CWError(1, 'Source type not found.', {'provided': source_type, 'options':this.activityTypes}))
-      }
-      if(!this.activityTypes.has(destination_type)) {
-        reject(new CWError(2, 'Destination type not found.', {'provided': destination_type, 'options':this.activityTypes}))
-      }
-      if(!this.linkTypes.has(link_type)) {
-        reject(new CWError(3, 'Link type not found.', {'provided': link_type, 'options':this.linkTypes}))
-      }
-      let data = {
-        SourceType: this.activityTypes.get(source_type),
-        SourceSid: source_sid,
-        DestType: this.activityTypes.get(destination_type),
-        DestSid: destination_sid,
-        LinkType: this.linkTypes.get(link_type)
-      }
-      let path = 'General/ActivityLink/Add'
-      this.cw.runRequest(path, data).then((response: any) => {
-        resolve(response.Value)
-      }).catch(e => {
-        reject(e)
-      })
+      this.validateType(source_type, this.activityTypes, 1);
+      this.validateType(destination_type, this.activityTypes, 2);
+      this.validateType(link_type, this.linkTypes, 3);
+
+      let data = this.setLinkData(source_type, source_sid, destination_type, destination_sid, link_type);
+      let path = 'General/ActivityLink/Add';
+
+      this.runRequest(path, data)
+        .then((response: any) => resolve(response.Value))
+        .catch(reject);
     })
   }
 
@@ -95,28 +128,19 @@ export class ActivityLinks implements ActivityLink {
    */
   get(type: string, sids: Array<number>) {
     return new Promise((resolve, reject) => {
-      if(!this.activityTypes.has(type)) {
-        reject(new CWError(4, 'Activity type not found.', {'provided': type, 'options':this.activityTypes}))
-      }
+      this.validateType(type, this.activityTypes, 4);
+
       let data = {
         ActivityType: this.activityTypes.get(type),
         ActivitySids: sids
-      }
-      let _this = this
-      let path = 'General/ActivityLink/ByActivitySids'
-      this.cw.runRequest(path, data).then((response: any) => {
-        let return_data = new Array()
-        _.forEach(response.Value, (link, key) => {
-          link.DestType = _this.activityTypes.get(link.DestType)
-          link.SourceType = _this.activityTypes.get(link.SourceType)
-          link.LinkType = _this.linkTypes.get(link.LinkType)
-          return_data.push(link)
-        })
-        resolve(return_data)
-      }).catch(e => {
-        reject(e)
-      })
-    })
+      };
+      // let _this = this
+      let path = 'General/ActivityLink/ByActivitySids';
+
+      this.runRequest(path, data)
+        .then((response: any) => resolve(this.transformLinksData(response)))
+        .catch(reject);
+    });
   }
 
   /**
@@ -130,24 +154,15 @@ export class ActivityLinks implements ActivityLink {
    */
   clone(source_type: string, source_sid: number, destination_type: string, destination_sid: number) {
     return new Promise((resolve, reject) => {
-      if(!this.activityTypes.has(source_type)) {
-        reject(new CWError(5, 'Source type not found.', {'provided': source_type, 'options':this.activityTypes}))
-      }
-      if(!this.activityTypes.has(destination_type)) {
-        reject(new CWError(6, 'Destination type not found.', {'provided': destination_type, 'options':this.activityTypes}))
-      }
-      let data = {
-        SourceActivityType: this.activityTypes.get(source_type),
-        SourceActivitySid: source_sid,
-        DestinationActivityType: this.activityTypes.get(destination_type),
-        DestinationActivitySid: destination_sid
-      }
-      let path = 'General/ActivityLink/CloneByActivitySid'
-      this.cw.runRequest(path, data).then((response: any) => {
-        resolve(response.Value)
-      }).catch(e => {
-        reject(e)
-      })
+      this.validateType(source_type, this.activityTypes, 5);
+      this.validateType(destination_type, this.activityTypes, 6);
+
+      let data = this.setLinkData(source_type, source_sid, destination_type, destination_sid);
+      let path = 'General/ActivityLink/CloneByActivitySid';
+
+      this.runRequest(path, data)
+        .then((response: any) => resolve(response.Value))
+        .catch(reject)
     })
   }
 
@@ -163,13 +178,10 @@ export class ActivityLinks implements ActivityLink {
         ActivityLinkId: activity_link_id
       }
       let path = 'General/ActivityLink/Delete'
-      this.cw.runRequest(path, data).then((response: any) => {
-        // console.log('response_raw', response)
-        resolve(response)
-      }).catch(e => {
-        // console.log('AL::Delete::e', e)
-        reject(e)
-      })
+
+      this.runRequest(path, data)
+        .then((response: any) => resolve(response))
+        .catch(reject)
     })
   }
 
@@ -185,28 +197,16 @@ export class ActivityLinks implements ActivityLink {
    */
   remove(source_type: string, source_sid: number, destination_type: string, destination_sid: number, link_type: string = 'related') {
     return new Promise((resolve, reject) => {
-      if(!this.activityTypes.has(source_type)) {
-        reject(new CWError(8, 'Source type not found.', {'provided': source_type, 'options':this.activityTypes}))
-      }
-      if(!this.activityTypes.has(destination_type)) {
-        reject(new CWError(9, 'Destination type not found.', {'provided': destination_type, 'options':this.activityTypes}))
-      }
-      if(!this.linkTypes.has(link_type)) {
-        reject(new CWError(10, 'Link type not found.', {'provided': link_type, 'options':this.linkTypes}))
-      }
-      let data = {
-        SourceType: this.activityTypes.get(source_type),
-        SourceSid: source_sid,
-        DestType: this.activityTypes.get(destination_type),
-        DestSid: destination_sid,
-        LinkType: this.linkTypes.get(link_type)
-      }
-      let path = 'General/ActivityLink/Remove'
-      this.cw.runRequest(path, data).then((response: any) => {
-        resolve(response.Value)
-      }).catch(e => {
-        reject(e)
-      })
+      this.validateType(source_type, this.activityTypes, 8);
+      this.validateType(destination_type, this.activityTypes, 9);
+      this.validateType(link_type, this.linkTypes, 10);
+
+      let data = this.setLinkData(source_type, source_sid, destination_type, destination_sid, link_type);
+      let path = 'General/ActivityLink/Remove';
+
+      this.runRequest(path, data)
+        .then((response: any) => resolve(response.Value))
+        .catach(reject)
     })
   }
 }

--- a/test/02.activitylinkTest.js
+++ b/test/02.activitylinkTest.js
@@ -25,8 +25,8 @@ describe('[ActivityLink (construct)] function test', () => {
 describe('[ActivityLink::get] function test', () => {
   it('should return error if type doesn\'t exist', (done) => {
     cw2.activity_link.get('something').then(resp => {
-    }).catch(error => {
-      assert.equal(error.message, 'Activity type not found.');
+    }).catch(e => {
+      expect(e.message).to.have.string('not found.').and.to.have.string('Activity type');
       done();
     });
   });
@@ -46,7 +46,11 @@ describe('[ActivityLink::add] function test', () => {
   it('should return the new link', (done) => {
     cw2.activity_link.add('workorder', 241437, 'workorder', 241525).then(resp => {
       assert.isNumber(resp.ActivityLinkId);
-      done();
+      cw2.activity_link.delete(resp.ActivityLinkId).then(r => {
+        done();
+      }).catch(error => {
+        done();
+      });
     }).catch(error => {
       console.log(error)
       done();
@@ -67,45 +71,46 @@ describe('[ActivityLink::clone] function test', () => {
 });
 
 describe('[ActivityLink::delete] function test', () => {
-  it('should fail to delete an activity link if it is a parent/child relationship', (done) => {
-    cw2.activity_link.delete(477102).then(resp => {
-      console.log('resp', resp)
-      done();
-    }).catch(error => {
-      assert.equal(error.error_messages[0].Name, 'Cannot Delete Parent Links');
-      done();
-    });    
-  });
-  // it('should delete an activity link if the ID is found', (done) => {
+  // it('should fail to delete an activity link if it is a parent/child relationship', (done) => {
   //   cw2.activity_link.delete(477102).then(resp => {
-  //     console.log(resp);
-  //     // assert.isArray(resp);
+  //     // console.log('resp', resp)
   //     done();
   //   }).catch(error => {
-  //     console.log(error)
+  //     assert.equal(error.error_messages[0].Name, 'Cannot Delete Parent Links');
   //     done();
   //   });    
   // });
-  // it('should fail to delete an activity link if the ID cannot be found', (done) => {
-  //   cw2.activity_link.delete(477102).then(resp => {
-  //     console.log(resp);
-  //     assert.isArray(resp);
-  //     done();
-  //   }).catch(error => {
-  //     console.log(error)
-  //     done();
-  //   });
-  // });
+  it('should delete an activity link if the ID can be found and deleted', (done) => {
+    cw2.activity_link.add('workorder', 241437, 'workorder', 241525).then(resp => {
+      cw2.activity_link.delete(resp.ActivityLinkId).then(r => {
+        assert.isTrue(r);
+        done();
+      }).catch(error => {
+        done(error);
+      });
+    }).catch(error => {
+      done(error);
+    });
+  });
+  it('should fail to delete an activity link if the ID cannot be found', (done) => {
+    cw2.activity_link.delete(0).then(resp => {
+      assert.isTrue(resp);
+      done();
+    }).catch(error => {
+      done(error);
+    });
+  });
 });
+
 
 describe('[ActivityLink::remove] function test', () => {
   it('should remove a link when found', (done) => {
-    cw2.activity_link.remove().then(resp => {
-      assert.isArray(resp);
+    cw2.activity_link.remove('inspection', 53217, 'request', 1089178).then(resp => {
+      assert.isTrue(resp);
       done();
     }).catch(error => {
       console.log(error)
-      done();
+      // done();
     });
   });
 });


### PR DESCRIPTION
Refactored activity-links.ts file, separating concerns, removing unneeded lodash import, organizing code, and cleaning up promise handling.

- Created 6 private variables:
    - ``setActivityTypes`` and ``setLinkTypes`` moves the mapping of the activity types and link types outside of the constructor to separate concerns
    - ``validateType`` handles all error throwing should a type not be found
    - ``setLinkData`` returns the necessary results with an optional ``linkType``
    - ``transformLinksData`` transforms the raw response to a consistent format
    - ``runRequest`` isolates the request processing
    
- The ``lodash`` import is no longer needed, so it was removed

- Set all private variables at the top for more organized code

- Promise handling now uses the resolve and reject calls for readability